### PR TITLE
Fix IMDB snarfing

### DIFF
--- a/plugins/imdb.py
+++ b/plugins/imdb.py
@@ -5,7 +5,7 @@ import requests
 from cloudbot import hook
 
 id_re = re.compile(r'tt\d+')
-imdb_re = re.compile(r'https?://(?:www\.)?imdb\.com[/\\]+title[/\\]+(tt[0-9]+)', re.I)
+imdb_re = re.compile(r'https?://(?:www\.)?imdb\.com/+title/+(tt[0-9]+)', re.I)
 
 
 @hook.command

--- a/plugins/imdb.py
+++ b/plugins/imdb.py
@@ -5,7 +5,7 @@ import requests
 from cloudbot import hook
 
 id_re = re.compile(r'tt\d+')
-imdb_re = re.compile(r'(.*:)//(imdb.com|www.imdb.com)(:[0-9]+)?(.*)', re.I)
+imdb_re = re.compile(r'https?://(?:www\.)?imdb\.com[/\\]+title[/\\]+(tt[0-9]+)', re.I)
 
 
 @hook.command
@@ -46,11 +46,7 @@ def imdb(text, bot):
 def imdb_url(match, bot):
     headers = {'User-Agent': bot.user_agent}
 
-    imdb_id = match.group(4).split('/')[-1]
-    if imdb_id == "":
-        imdb_id = match.group(4).split('/')[-2]
-
-    params = {'id': imdb_id}
+    params = {'id': match.group(1)}
     request = requests.get(
         "https://imdb-scraper.herokuapp.com/title",
         params=params,

--- a/tests/plugin_tests/test_imdb.py
+++ b/tests/plugin_tests/test_imdb.py
@@ -1,4 +1,3 @@
-import pytest
 from plugins.imdb import imdb_re
 
 def test_imdb_re():

--- a/tests/plugin_tests/test_imdb.py
+++ b/tests/plugin_tests/test_imdb.py
@@ -1,0 +1,21 @@
+import pytest
+from plugins.imdb import imdb_re
+
+def test_imdb_re():
+    def match(text):
+        return imdb_re.match(text)
+
+    assert not match('http://www.imdb.com/title/stuff')
+
+    assert match('https://www.imdb.com/title/tt1950186/').group(1) == 'tt1950186'
+    assert match('https://www.imdb.com/title/tt2575988/mediaviewer/rm668743424?ft0=name&fv0=nm1476909&ft1=image_type&fv1=still_frame').group(1) == 'tt2575988'
+    assert match('http://www.imdb.com/title/tt1950186/').group(1) == 'tt1950186'
+    assert match('http://www.imdb.com/title/tt2575988/mediaviewer/rm668743424?ft0=name&fv0=nm1476909&ft1=image_type&fv1=still_frame').group(1) == 'tt2575988'
+    assert match('https://imdb.com/title/tt1950186/').group(1) == 'tt1950186'
+    assert match('https://imdb.com/title/tt2575988/mediaviewer/rm668743424?ft0=name&fv0=nm1476909&ft1=image_type&fv1=still_frame').group(1) == 'tt2575988'
+    assert match('http://imdb.com/title/tt1950186/').group(1) == 'tt1950186'
+    assert match('http://imdb.com/title/tt2575988/mediaviewer/rm668743424?ft0=name&fv0=nm1476909&ft1=image_type&fv1=still_frame').group(1) == 'tt2575988'
+    assert match('https://www.imdb.com/title/tt1950186').group(1) == 'tt1950186'
+    assert match('http://www.imdb.com/title/tt1950186').group(1) == 'tt1950186'
+    assert match('https://imdb.com/title/tt1950186').group(1) == 'tt1950186'
+    assert match('http://imdb.com/title/tt1950186').group(1) == 'tt1950186'


### PR DESCRIPTION
The old regex was super complicated for no apparent reason. Updated it to only grab the `ttXXXXXX` part of the URL.

This fixes IMDB snarfing for URLs like:

* https://www.imdb.com/title/tt2575988/mediaviewer/rm668743424?ft0=name&fv0=nm1476909&ft1=image_type&fv1=still_frame

Manually verified in #gonzobot 