### PR TITLE
Bugfix for Issue #39 - .urban fails if query end in a numeric character.

### DIFF
--- a/plugins/urban.py
+++ b/plugins/urban.py
@@ -24,7 +24,8 @@ def urban(text, reply):
         parts = text.split()
 
         # if the last word is a number, set the ID to that number
-        if parts[-1].isdigit():
+        # but not if its the only word, in which case the number is the query
+        if parts[-1].isdigit() and len(parts) > 1:
             id_num = int(parts[-1])
             # remove the ID from the input string
             del parts[-1]


### PR DESCRIPTION
Details: Line 27, it checks if the last word is a number and if it is, it sets the ID to that number. However, it doesn't check if the word is the only word, in which case it is the query, not the ID.