### PR TITLE
Fix description fetching for the wikipedia plugin

### DIFF
--- a/plugins/wikipedia.py
+++ b/plugins/wikipedia.py
@@ -17,7 +17,7 @@ random_url = api_prefix + "?action=query&format=xml&list=random&rnlimit=1&rnname
 paren_re = re.compile(r'\s*\(.*\)$')
 
 
-def get_description(request_title):
+def get_description(request_title, reply):
     """ Returns the description of the wikipedia article with the requested title. """
     try:
         maximum_desc_len = 200
@@ -67,11 +67,11 @@ def wiki(text, reply):
 
     title, url = extract(items[0])
 
-    desc = get_description(title)
+    desc = get_description(title, reply)
 
     if 'may refer to' in desc:
         title, url = extract(items[1])
-        desc = get_description(title)
+        desc = get_description(title, reply)
 
     title = paren_re.sub('', title)
 

--- a/plugins/wikipedia.py
+++ b/plugins/wikipedia.py
@@ -11,6 +11,7 @@ from cloudbot.util.http import parse_xml
 
 api_prefix = "http://en.wikipedia.org/w/api.php"
 search_url = api_prefix + "?action=opensearch&format=xml"
+description_fetch_url = api_prefix + "?action=query&format=xml&prop=extracts&explaintext=true&exintro=true&exsectionformat=plain"
 random_url = api_prefix + "?action=query&format=xml&list=random&rnlimit=1&rnnamespace=0"
 
 paren_re = re.compile(r'\s*\(.*\)$')
@@ -40,12 +41,35 @@ def wiki(text, reply):
 
     def extract(item):
         return [item.find(ns + i).text for i in
-                ('Text', 'Description', 'Url')]
+                ('Text', 'Url')]
 
-    title, desc, url = extract(items[0])
+    title, url = extract(items[0])
+
+    def get_description(request_title):
+        try:
+            maximum_desc_len = 200
+            desc_request_params = {'exchars': maximum_desc_len,
+                                   'titles': request_title}
+            description_request = requests.get(description_fetch_url, params=desc_request_params)
+            description_request.raise_for_status()
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            reply("Could not get Wikipedia page description: {}".format(e))
+            raise
+
+        y = parse_xml(description_request.text)
+        try:
+            plain_desc = y.find('query').find('pages').find('page').find('extract').text
+        except AttributeError as e:
+            reply("Could not extract the description of the article: {}".format(e))
+            raise
+
+        return plain_desc
+
+    desc = get_description(title)
 
     if 'may refer to' in desc:
-        title, desc, url = extract(items[1])
+        title, url = extract(items[1])
+        desc = get_description(title)
 
     title = paren_re.sub('', title)
 


### PR DESCRIPTION
Added a new API request to fetch the description.

The description is not returned anymore in the opensearch call, as explained in #69 .
