### PR TITLE
Replace term that produces grammatical error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix matching exception in horoscope test
 - Fix youtube.py ISO time parse
+- Fix grammatical error in food sentence (beer)
 
 ## [1.3.0] 2020-03-17
 ### Added

--- a/data/food/beer.json
+++ b/data/food/beer.json
@@ -1,14 +1,14 @@
 {
     "templates": [
-        "hands {user} a {size} {container} of {beer}."
+        "hands {user} {size} {container} of {beer}."
     ],
     "parts": {
         "size": [
-            "small",
-            "medium",
-            "large",
-            "gigantic",
-            "half-empty"
+            "a small",
+            "a medium",
+            "a large",
+            "an enormous",
+            "a half-empty"
         ],
         "container": [
             "glass",

--- a/data/food/beer.json
+++ b/data/food/beer.json
@@ -7,7 +7,7 @@
             "small",
             "medium",
             "large",
-            "enormous",
+            "gigantic",
             "half-empty"
         ],
         "container": [


### PR DESCRIPTION
`enormous` can result in a sentence like:
`* gonzobot hands <user> a enormous mug of American ale.`

Clearly, "a enormous" is grammatically incorrect.

I propose "gigantic" instead, which fits with "a gigantic".

Another proposed solution that keeps enormous would be this:
```json
{
    "templates": [
        "hands {user} a{size} {container} of {beer}."
    ],
    "parts": {
        "size": [
            " small",
            " medium",
            " large",
            "n enormous",
            " half-empty"
        ],
```
As you can see, the space between`a` and `{size}` is removed, and inserted in the variable value again, while prepending `n` for `enormous`.
This is not pretty though.