### PR TITLE
Fix removal of special characters for herald clean

### DIFF
--- a/plugins/herald.py
+++ b/plugins/herald.py
@@ -106,7 +106,7 @@ def welcome(nick, message, bot, chan):
 
     greet = herald_cache[chan.casefold()].get(nick.casefold())
     if greet:
-        stripped = greet.translate(dict.fromkeys(["\u200b", " ", "\u202f", "\x02"]))
+        stripped = greet.translate(dict.fromkeys(map(ord, ["\u200b", " ", "\u202f", "\x02"])))
         stripped = colors_re.sub("", stripped)
         greet = re.sub(bino_re, 'flenny', greet)
         greet = re.sub(offensive_re, ' freespeech oppression ', greet)

--- a/tests/plugin_tests/test_herald.py
+++ b/tests/plugin_tests/test_herald.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from cloudbot.event import Event
+from plugins import herald
+from tests.util import wrap_hook_response
+
+
+@pytest.fixture()
+def clear_cache():
+    try:
+        yield
+    finally:
+        herald.herald_cache.clear()
+
+
+@pytest.fixture()
+def unset_timeout():
+    try:
+        yield
+    finally:
+        herald.floodcheck.clear()
+
+
+@pytest.mark.usefixtures("unset_timeout")
+class TestWelcome:
+    def _run(self):
+        conn = MagicMock()
+        event = Event(
+            hook=MagicMock(),
+            bot=conn.bot,
+            conn=conn,
+            channel='#foo',
+            nick='foobaruser'
+        )
+        return wrap_hook_response(herald.welcome, event)
+
+    def test_no_herald(self):
+        result = self._run()
+        assert result == []
+
+    @pytest.mark.parametrize('text,out', [
+        ('Hello world', '\u200b Hello world'),
+        ('bino', '\u200b flenny'),
+        ('\u200b hi', '\u200b \u200b hi'),
+        ('o\u200b<', 'DECOY DUCK --> o\u200b<'),
+    ])
+    def test_char_strip(self, clear_cache, text, out):
+        herald.herald_cache['#foo']['foobaruser'] = text
+        result = self._run()
+        assert result == [('message', ('#foo', out))]


### PR DESCRIPTION
A statement in the `herald` plugin has no effect without this fix.

Before:
```python
>>> "asdf\u200bfdsa".translate(dict.fromkeys(["\u200b", " ", "\u202f", "\x02"]))
'asdf\u200bfdsa'
```
After:
```python
>>> "asdf\u200bfdsa".translate(dict.fromkeys(map(ord, ["\u200b", " ", "\u202f", "\x02"])))
'asdffdsa'
```
---
E.g. with the duck:
Before:
```python
>>> duck[0].translate(dict.fromkeys(["\u200b", " ", "\u202f", "\x02"]))
'・゜゜・。 \u200b 。・゜゜'
```

After:
```python
>>> duck[0].translate(dict.fromkeys(map(ord, ["\u200b", " ", "\u202f", "\x02"])))
'・゜゜・。。・゜゜'
```