### PR TITLE
refactor: move to using attribute constants for hook attributes

### DIFF
--- a/cloudbot/bot.py
+++ b/cloudbot/bot.py
@@ -23,7 +23,7 @@ from cloudbot.event import CommandEvent, Event, EventType, RegexEvent
 from cloudbot.hook import Action
 from cloudbot.plugin import PluginManager
 from cloudbot.reloader import ConfigReloader, PluginReloader
-from cloudbot.util import async_util, database, formatting
+from cloudbot.util import CLIENT_ATTR, async_util, database, formatting
 from cloudbot.util.mapping import KeyFoldDict
 
 logger = logging.getLogger("cloudbot")
@@ -328,7 +328,7 @@ class CloudBot(AbstractBot):
                     continue
 
                 try:
-                    _type = obj._cloudbot_client  # type: ignore
+                    _type = getattr(obj, CLIENT_ATTR)
                 except AttributeError:
                     continue
 

--- a/cloudbot/client.py
+++ b/cloudbot/client.py
@@ -5,14 +5,14 @@ import random
 from typing import Any, Dict
 
 from cloudbot.permissions import PermissionManager
-from cloudbot.util import async_util
+from cloudbot.util import CLIENT_ATTR, async_util
 
 logger = logging.getLogger("cloudbot")
 
 
 def client(_type):
     def _decorate(cls):
-        cls._cloudbot_client = _type
+        setattr(cls, CLIENT_ATTR, _type)
         return cls
 
     return _decorate

--- a/cloudbot/util/__init__.py
+++ b/cloudbot/util/__init__.py
@@ -2,4 +2,5 @@
 
 ATTR_PREFIX = "_cloudbot"
 HOOK_ATTR = ATTR_PREFIX + "_hook"
+CLIENT_ATTR = ATTR_PREFIX + "_client"
 LOADED_ATTR = ATTR_PREFIX + "_loaded"

--- a/tests/core_tests/test_hook.py
+++ b/tests/core_tests/test_hook.py
@@ -66,27 +66,27 @@ def test_hook_decorate():
     def f():
         raise NotImplementedError
 
-    assert f._cloudbot_hook["event"].types == {
+    assert getattr(f, HOOK_ATTR)["event"].types == {
         EventType.message,
         EventType.notice,
         EventType.action,
     }
-    assert f._cloudbot_hook["command"].aliases == {"test"}
-    assert f._cloudbot_hook["irc_raw"].triggers == {"*", "PRIVMSG"}
+    assert getattr(f, HOOK_ATTR)["command"].aliases == {"test"}
+    assert getattr(f, HOOK_ATTR)["irc_raw"].triggers == {"*", "PRIVMSG"}
 
-    assert "irc_out" in f._cloudbot_hook
-    assert "on_start" in f._cloudbot_hook
-    assert "on_stop" in f._cloudbot_hook
-    assert "regex" in f._cloudbot_hook
-    assert "periodic" in f._cloudbot_hook
-    assert "perm_check" in f._cloudbot_hook
-    assert "post_hook" in f._cloudbot_hook
-    assert "on_connect" in f._cloudbot_hook
-    assert "on_cap_available" in f._cloudbot_hook
-    assert "on_cap_ack" in f._cloudbot_hook
+    assert "irc_out" in getattr(f, HOOK_ATTR)
+    assert "on_start" in getattr(f, HOOK_ATTR)
+    assert "on_stop" in getattr(f, HOOK_ATTR)
+    assert "regex" in getattr(f, HOOK_ATTR)
+    assert "periodic" in getattr(f, HOOK_ATTR)
+    assert "perm_check" in getattr(f, HOOK_ATTR)
+    assert "post_hook" in getattr(f, HOOK_ATTR)
+    assert "on_connect" in getattr(f, HOOK_ATTR)
+    assert "on_cap_available" in getattr(f, HOOK_ATTR)
+    assert "on_cap_ack" in getattr(f, HOOK_ATTR)
 
-    assert len(f._cloudbot_hook["regex"].regexes) == 4
-    assert f._cloudbot_hook["periodic"].interval == 20
+    assert len(getattr(f, HOOK_ATTR)["regex"].regexes) == 4
+    assert getattr(f, HOOK_ATTR)["periodic"].interval == 20
 
     with pytest.raises(ValueError, match="Invalid command name test 123"):
         hook.command("test 123")(f)
@@ -107,13 +107,13 @@ def test_hook_decorate():
     def sieve_func(_bot, _event, _hook):
         raise NotImplementedError
 
-    assert "sieve" in sieve_func._cloudbot_hook
+    assert "sieve" in getattr(sieve_func, HOOK_ATTR)
 
     @hook.sieve()
     def sieve_func2(_bot, _event, _hook):
         raise NotImplementedError
 
-    assert "sieve" in sieve_func2._cloudbot_hook
+    assert "sieve" in getattr(sieve_func2, HOOK_ATTR)
 
     @hook.on_connect()
     @hook.irc_out()
@@ -123,7 +123,7 @@ def test_hook_decorate():
     def plain_dec(_bot, _event, _hook):
         raise NotImplementedError
 
-    assert sorted(plain_dec._cloudbot_hook.keys()) == [
+    assert sorted(getattr(plain_dec, HOOK_ATTR).keys()) == [
         "irc_out",
         "on_connect",
         "on_start",
@@ -141,7 +141,7 @@ def test_command_hook_doc():
 
         foo"""
 
-    cmd_hook = test._cloudbot_hook["command"]
+    cmd_hook = getattr(test, HOOK_ATTR)["command"]
     assert cmd_hook.doc == "<arg> - foo bar baz"
 
     @hook.command()
@@ -150,14 +150,14 @@ def test_command_hook_doc():
 
         foo"""
 
-    cmd_hook = test1._cloudbot_hook["command"]
+    cmd_hook = getattr(test1, HOOK_ATTR)["command"]
     assert cmd_hook.doc == "<arg> - foo bar baz"
 
     @hook.command()
     def test2(bot):
         """<arg> - foo bar baz"""
 
-    cmd_hook = test2._cloudbot_hook["command"]
+    cmd_hook = getattr(test2, HOOK_ATTR)["command"]
     assert cmd_hook.doc == "<arg> - foo bar baz"
 
     @hook.command()
@@ -166,12 +166,12 @@ def test_command_hook_doc():
         <arg> - foo bar baz
         """
 
-    cmd_hook = test3._cloudbot_hook["command"]
+    cmd_hook = getattr(test3, HOOK_ATTR)["command"]
     assert cmd_hook.doc == "<arg> - foo bar baz"
 
     @hook.command()
     def test4(bot):
         """<arg> - foo bar baz"""
 
-    cmd_hook = test4._cloudbot_hook["command"]
+    cmd_hook = getattr(test4, HOOK_ATTR)["command"]
     assert cmd_hook.doc == "<arg> - foo bar baz"

--- a/tests/core_tests/test_plugin_hooks.py
+++ b/tests/core_tests/test_plugin_hooks.py
@@ -45,6 +45,7 @@ from cloudbot.hook import (
 )
 from cloudbot.plugin import Plugin
 from cloudbot.plugin_hooks import Hook, hook_name_to_plugin
+from cloudbot.util import HOOK_ATTR
 from tests.util.mock_bot import MockBot
 
 DOC_RE = re.compile(r"^(?:[<{\[][^-]+?[>}\]][^-]+?)*?-\s.+$")
@@ -256,7 +257,7 @@ def make_plugin():
 
 
 def get_and_wrap_hook(func, hook_type):
-    func_hook = func._cloudbot_hook[hook_type]
+    func_hook = getattr(func, HOOK_ATTR)[hook_type]
     plugin = make_plugin()
 
     _hook = hook_name_to_plugin(hook_type)(plugin, func_hook)


### PR DESCRIPTION
This makes access more consistent and also silences warnings about missing attributes